### PR TITLE
Bugfix branch

### DIFF
--- a/frontend/msSmash.pas
+++ b/frontend/msSmash.pas
@@ -355,7 +355,7 @@ begin
           mst := WinningOverrideInFiles(rec, plugin.masters);
         Tracker.Write(Format('    Smashing override from: %s, master: %s',
           [f.FileName, mst._File.FileName]));
-        AddRequiredMasters(patch.plugin._File, e);
+        AddRequiredMasters(patch.plugin._File, ovr);
         rcore(IwbElement(ovr), IwbElement(mst), IwbElement(patchRec), patchRec,
           recObj, false, bDeletions, bOverride);
       except

--- a/lib/mte/mteBase.pas
+++ b/lib/mte/mteBase.pas
@@ -1372,6 +1372,9 @@ begin
     for i := 0 to Pred(recDef.MemberCount) do
       BuildChildDef(recDef.Members[i] as IwbNamedDef, recObj);
   end
+  else if (def.DefType = dtSubRecordStruct) or (def.DefType = dtSubRecordArray) then begin
+    AddDefIfMissing(recObj, def, def.Name);
+  end
   else if Supports(def, IwbSignatureDef, sigDef) then begin
     name := SigToStr(sigDef.DefaultSignature) + ' - ' + sigDef.Name;
     AddDefIfMissing(recObj, def, name);


### PR DESCRIPTION
The following changes are to fix the error:
"CopyElementValue: Exception Load order FileID [02] can not be mapped to file FileID for file "XXXXXXX.esp"" by adding the masters from the overriding elements plugin

And also fix Structs and Struct Arrays from being prefixed with a signature when creating new settings